### PR TITLE
Add stale.yml workflow for managing inactive issues and PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,27 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '36 7 * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'Stale issue message'
+        stale-pr-message: 'Stale pull request message'
+        stale-issue-label: 'no-issue-activity'
+        stale-pr-label: 'no-pr-activity'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -26,8 +26,12 @@ jobs:
           If you believe this issue is still important, please add a comment with any updates or additional details.
           Any new activity will remove the stale label and keep the issue open; otherwise, it may be closed automatically.
         stale-pr-message: |
-          This pull request has been automatically marked as stale because there has been no recent activity.
-          If you intend to continue working on this change, please add a comment, push new commits, or otherwise update the pull request.
-          Any new activity will remove the stale label and keep the pull request open; otherwise, it may be closed automatically.
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        days-before-stale: 60
+        days-before-close: 7
+        stale-issue-message: 'Stale issue message'
+        stale-pr-message: 'Stale pull request message'
         stale-issue-label: 'no-issue-activity'
         stale-pr-label: 'no-pr-activity'
+        exempt-issue-labels: 'pinned,security,never-stale'
+        exempt-pr-labels: 'pinned,security,never-stale'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,7 @@ name: Mark stale issues and pull requests
 
 on:
   schedule:
-  - cron: '36 7 * * *'
+    - cron: '36 7 * * *'
   workflow_dispatch:
 jobs:
   stale:
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/stale@v5
+    - uses: actions/stale@v9
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: |

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,7 +8,7 @@ name: Mark stale issues and pull requests
 on:
   schedule:
   - cron: '36 7 * * *'
-
+  workflow_dispatch:
 jobs:
   stale:
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,7 +21,13 @@ jobs:
     - uses: actions/stale@v5
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'Stale issue message'
-        stale-pr-message: 'Stale pull request message'
+        stale-issue-message: |
+          This issue has been automatically marked as stale because there has been no recent activity.
+          If you believe this issue is still important, please add a comment with any updates or additional details.
+          Any new activity will remove the stale label and keep the issue open; otherwise, it may be closed automatically.
+        stale-pr-message: |
+          This pull request has been automatically marked as stale because there has been no recent activity.
+          If you intend to continue working on this change, please add a comment, push new commits, or otherwise update the pull request.
+          Any new activity will remove the stale label and keep the pull request open; otherwise, it may be closed automatically.
         stale-issue-label: 'no-issue-activity'
         stale-pr-label: 'no-pr-activity'


### PR DESCRIPTION
This workflow automatically marks issues and pull requests as stale based on inactivity, with configurable messages and labels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds a new GitHub Actions workflow (.github/workflows/stale.yml) to automatically mark inactive issues and pull requests as stale and optionally close them. It runs on a cron schedule (36 7 * * *) and via workflow_dispatch, uses actions/stale@v9, and grants write permissions for issues and pull-requests. It intends to label stale items (no-issue-activity / no-pr-activity), exempt pinned/security/never-stale labels, and configure timing (60 days before marking stale, 7 days before closing).

Why this was needed
- Automates backlog housekeeping and notifies contributors about stalled issues/PRs to improve project health.

What to fix before merging
- Misplaced/duplicated workflow inputs: the steps block contains duplicated and misordered keys — an empty multiline stale-pr-message block is followed by a second repo-token line, and repo-token plus message keys are repeated later. Clean up the with: inputs so repo-token appears once and each message (stale-issue-message, stale-pr-message) is a single properly indented value.
- Confirm message contents: replace the placeholder single-line messages or consolidate the intended multiline message(s) so they aren’t partially overwritten by duplicate keys.
- Verify action version compatibility: actions/stale@v9 is acceptable (Node 20). If you instead choose v10 (Node 24), ensure runner >= v2.327.1. Run the workflow in CI to confirm behavior after fixing inputs.

Impact
- After cleaning the inputs and verifying the chosen stale action version, the workflow will reduce manual maintenance of inactive issues/PRs and improve contributor communication. As-is the duplicated/misplaced keys will prevent the intended messages and configuration from being applied correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->